### PR TITLE
fixed the mypy error

### DIFF
--- a/app/bots/discord/custom_context.py
+++ b/app/bots/discord/custom_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 from discord.ext import commands
 from sqlalchemy.orm import Session
 
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
 class CustomContext(commands.Context):
     """An extended context to use in commands with often-used data to avoid boilerplate code."""
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.account: Account
-        self.db_session: Session
+
+        # Initialize attributes so mypy knows they exist
+        self.account: Optional["Account"] = None
+        self.db_session: Optional[Session] = No


### PR DESCRIPTION
Updated CustomContext to include type hints for account and db_session attributes.  Mypy requires instance variables to be:
✔ Initialized in __init__
✔ OR declared as ClassVar
✔ OR always assigned before use